### PR TITLE
fix: dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,18 +12,6 @@ updates:
   commit-message:
     prefix: chore
 
-- package-ecosystem: poetry
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  assignees:
-  - thenativeweb/internal_dev
-  labels:
-  - Dependencies
-  commit-message:
-    prefix: chore
-
 - package-ecosystem: docker
   directory: "/tests/shared/docker/eventsourcingdb"
   schedule:


### PR DESCRIPTION
## Fix
The configuration file for Dependabot **must** be named `dependabot.yml` and placed inside the `.github/` directory of your repository.  
If you instead name the file `.dependabot.yml` (with a leading dot), GitHub will ignore it, and Dependabot will not work as expected.

### Update

```
your-repo/
├── .github/
│   └── dependabot.yml 
├── pyproject.toml
├── poetry.lock
```

For more information on proper configuration, refer to the official GitHub documentation:

- [[Dependabot options reference – GitHub Docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)
