### PR TITLE
chore: keep uv.lock in sync automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     cooldown:
       default-days: 7
@@ -15,14 +15,14 @@ updates:
       prefix: fix
       prefix-development: chore
     groups:
-      pip-production:
+      uv-production:
         dependency-type: production
         patterns:
           - "*"
         update-types:
           - minor
           - patch
-      pip-development:
+      uv-development:
         dependency-type: development
         patterns:
           - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,10 @@ jobs:
       if: ${{ steps.get_next_version.outputs.hasNextVersion == 'true' }}
       run: |
         sed -i -r "s/(version = \")([0-9]+\.[0-9]+\.[0-9]+)(\")/\1${{ steps.get_next_version.outputs.version }}\3/" pyproject.toml
+        uv lock
         git config --global user.email "hello@thenativeweb.io"
         git config --global user.name "${{ github.actor }}"
-        git add pyproject.toml
+        git add pyproject.toml uv.lock
         git commit -m 'chore: Bump version to ${{ steps.get_next_version.outputs.version }}. [skip ci]'
         git push
         git tag ${{ steps.get_next_version.outputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,15 @@ PACKAGE := eventsourcingdb
 TEST_DIR := tests
 PYTHON_DIRS := $(PACKAGE) $(TEST_DIR)
 
-qa: analyze typecheck security test 
+qa: verify-lock analyze typecheck security test
 
 analyze:
 	@echo "Running code analysis..."
 	@uv run ruff check $(PYTHON_DIRS)
+
+verify-lock:
+	@echo "Verifying dependency lock..."
+	@uv lock --check
 
 build: qa clean
 	@echo "Build prepared."
@@ -61,4 +65,5 @@ typecheck:
 		security \
 		test \
 		typecheck \
+		verify-lock \
 		clean

--- a/uv.lock
+++ b/uv.lock
@@ -492,7 +492,7 @@ wheels = [
 
 [[package]]
 name = "eventsourcingdb"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
`uv.lock` kept drifting behind `pyproject.toml`, so it had to be refreshed by hand in three of the four dependency PRs merged today. There are two independent causes:

**1. Dependabot ran as the `pip` ecosystem.** That ecosystem only understands `pyproject.toml` and never touches `uv.lock` — which is why #243, #245 and #247 landed with a stale lockfile. Dependabot has supported `uv` natively [since March 2025](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/); it reads and updates both files together. The group names were renamed `pip-*` → `uv-*` to match.

**2. The release workflow bumped the version without re-locking.** It rewrites `version` in `pyproject.toml` via `sed` and commits only that file. After the 1.9.1 release, `uv.lock` still declared `version = "1.9.0"` for the project itself. It now runs `uv lock` and commits the result alongside.

**Guard against regressions.** `make qa` gained a `verify-lock` step running `uv lock --check`, so any future drift turns the build red instead of going unnoticed — no matter whether it comes from Dependabot, the release pipeline or a manual edit.

Verified locally: `make verify-lock` fails on a deliberately introduced drift and passes on the refreshed lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3ADPwk11GHQF7BBwQHaPz